### PR TITLE
Allow use of API key

### DIFF
--- a/lib/distance_matrix_api.ex
+++ b/lib/distance_matrix_api.ex
@@ -27,6 +27,9 @@ defmodule DistanceMatrixApi do
   end
 
   defp make_request(params, options) do
+    if key do
+     params = Map.put(params, :key, key)
+    end
     params
     |> Map.merge(options)
     |> URI.encode_query
@@ -51,4 +54,9 @@ defmodule DistanceMatrixApi do
 
     body |> Poison.decode!
   end
+  
+  defp key do
+    Application.get_env(:distance_api_matrix, :api_key)
+  end
+
 end


### PR DESCRIPTION
Commit allows for the api key to be defined in config/config.exs like

```
config :distance_api_matrix, api_key: "<your_api_key>"
```
