### PR TITLE
Relax poison package version requirement 

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,7 @@ defmodule DistanceMatrixApi.Mixfile do
 
   defp deps do
     [{:httpoison, "~> 0.8.0"},
-    {:poison, "~> 1.5"},
+    {:poison, "~> 1.5 or ~> 2.0"},
     {:exvcr, "~> 0.6", only: :test}]
   end
 


### PR DESCRIPTION
Commit relaxes the Poison package version requirement. Some libraries require Poison `~> 2.0` so this commit allows using Poison `~> 1.0 or ~>  2.0` to resolve version conflicts.
